### PR TITLE
Add a merged_at field and starting with initial clusters

### DIFF
--- a/agglomerative.ml
+++ b/agglomerative.ml
@@ -16,11 +16,7 @@ module Make =
     (S : Element_set with type elt = E.t)
     ->
     struct
-      type cluster = { set : S.t; tree : tree; index : int }
-
-      and tree = Node of cluster * cluster | Leaf
-
-      let mkcluster index set tree = { set; tree; index }
+      type cluster = { index: int; set: S.t; children: (cluster * cluster) option; }
 
       let precompute_dist sets =
         let len = List.length sets * 2 - 1 in
@@ -32,76 +28,62 @@ module Make =
               )
           )
         in
-        fun i j ->
-          let i,j = min i j, max i j in
+        fun c1 c2 ->
+          let i,j = min c1.index c2.index, max c1.index c2.index in
           match table.(i).(j) with
           | Some dist -> dist
           | None ->
             let dist = S.dist (List.nth sets i) (List.nth sets j) in
             table.(i).(j) <- Some dist;
+            table.(j).(i) <- Some dist;
             dist
 
       let minimum_pairwise_distance dist clusters =
         match clusters with
         | [] | [_] -> invalid_arg "cluster list must contain at least two clusters"
         | c1 :: c2 :: _tl ->
-          let (acc, _) =
-            List.fold_left
-              (fun (acc, i) c1 ->
-                 let (acc, _) =
-                   List.fold_left
-                     (fun (acc, j) c2 ->
-                        let acc =
-                          if j > i then
-                            let (best_d, _, _) = acc in
-                            let d = dist i j in
-                            if d < best_d then (d, c1, c2) else acc
-                          else acc
-                        in
-                        (acc, j + 1))
-                     (acc, 0)
-                     clusters
-                 in
-                 (acc, i + 1))
-              ((dist c1.index c2.index, c1, c2), 0)
-              clusters
-          in
-          acc
-
-      let rec iterate i dist clusters =
-        match clusters with
-        | [] -> invalid_arg "empty cluster list"
-        | [c] -> c
-        | _ ->
-          let (_d, c, c') = minimum_pairwise_distance dist clusters in
-          let clusters =
-            List.filter (fun c0 -> c0.index <> c.index && c0.index <> c'.index) clusters
-          in
-          let joined = mkcluster i (S.join c.set c'.set) (Node (c, c')) in
-          iterate (i+1) dist (joined :: clusters)
+          let seq = List.to_seq clusters |> (fun x -> Seq.product x x) in
+          Seq.fold_left (fun ((dist_min, _, _) as acc) (a,b) ->
+              let dist_new = dist a b in
+              if a.index = b.index || dist_new >= dist_min
+              then acc
+              else (dist_new, a, b)
+            ) (dist c1 c2, c1, c2) seq
 
       let cluster_with_initial element_sets =
         let dist = precompute_dist element_sets in
+        let len = List.length element_sets in
         let clusters =
-          List.mapi (fun i x -> mkcluster i x Leaf) element_sets
+          List.mapi (fun index set -> {index; set; children = None; }) element_sets
         in
-        iterate (List.length element_sets) dist clusters
+
+        let rec iterate index clusters =
+          match clusters with
+          | [] -> failwith "No cluster left"
+          | [c] -> c
+          | cs ->
+            let _, left, right = minimum_pairwise_distance dist cs in
+            let set = S.join left.set right.set in
+            let clusters = {index; set; children = Some (left, right); } :: List.filter (fun x -> x.index = left.index || x.index = right.index) clusters in
+            iterate (index+1) clusters
+        in
+        iterate len clusters
 
       let cluster elements =
         List.map (fun x -> S.singleton x) elements
         |> cluster_with_initial
 
       let truncate cluster depth =
-        let rec truncate { set; tree; _ } depth queue acc =
-          match tree with
-          | Leaf -> (
+        let rec truncate { set; children; _ } depth queue acc =
+          match children with
+          | None -> (
               if depth > 0 then invalid_arg "truncate: tree too short"
               else
                 let acc = set :: acc in
                 match queue with
                 | [] -> acc
                 | (next, d) :: tl -> truncate next d tl acc)
-          | Node (l, r) ->
+          | Some (l, r) ->
             if depth = 0 then
               let acc = set :: acc in
               match queue with
@@ -112,10 +94,10 @@ module Make =
         truncate cluster depth [] []
 
       let all_clusters cluster =
-        let rec fold { set; tree; _ } depth acc =
-          match tree with
-          | Leaf -> (set, depth) :: acc
-          | Node (l, r) ->
+        let rec fold { set; children; _ } depth acc =
+          match children with
+          | None -> (set, depth) :: acc
+          | Some (l, r) ->
             fold r (depth + 1) (fold l (depth + 1) ((set, depth) :: acc))
         in
         fold cluster 0 []

--- a/agglomerative.ml
+++ b/agglomerative.ml
@@ -53,23 +53,21 @@ module Make =
               Table.add table (c1, c2) dist ;
               dist
 
-      let minimum_pairwise_distance (dist : cluster -> cluster -> float) clusters
-        =
+      let minimum_pairwise_distance (dist : cluster -> cluster -> float) clusters =
         match clusters with
-        | [] -> invalid_arg "empty cluster list"
-        | [c] -> (0.0, c, c)
-        | c :: c' :: _tl ->
+        | [] | [_] -> invalid_arg "cluster list must contain at least two clusters"
+        | c1 :: c2 :: _tl ->
           let (acc, _) =
             List.fold_left
-              (fun (acc, i) c ->
+              (fun (acc, i) c1 ->
                  let (acc, _) =
                    List.fold_left
-                     (fun (acc, j) c' ->
+                     (fun (acc, j) c2 ->
                         let acc =
                           if j > i then
                             let (best_d, _, _) = acc in
-                            let d = dist c c' in
-                            if d < best_d then (d, c, c') else acc
+                            let d = dist c1 c2 in
+                            if d < best_d then (d, c1, c2) else acc
                           else acc
                         in
                         (acc, j + 1))
@@ -77,7 +75,7 @@ module Make =
                      clusters
                  in
                  (acc, i + 1))
-              ((dist c c', c, c'), 0)
+              ((dist c1 c2, c1, c2), 0)
               clusters
           in
           acc

--- a/agglomerative.ml
+++ b/agglomerative.ml
@@ -92,13 +92,17 @@ module Make =
           let joined = mkcluster (S.join c.set c'.set) (Node (c, c')) in
           iterate dist (joined :: clusters)
 
-      let cluster elements =
-        let len = List.length elements in
+      let cluster_with_initial element_sets =
+        let len = List.length element_sets in
         let dist = dist len in
         let clusters =
-          List.map (fun x -> mkcluster (S.singleton x) Leaf) elements
+          List.map (fun x -> mkcluster x Leaf) element_sets
         in
         iterate dist clusters
+
+      let cluster elements =
+        List.map (fun x -> S.singleton x) elements
+        |> cluster_with_initial
 
       let truncate cluster depth =
         let rec truncate { set; tree; _ } depth queue acc =

--- a/agglomerative.ml
+++ b/agglomerative.ml
@@ -16,26 +16,41 @@ module Make =
     (S : Element_set with type elt = E.t)
     ->
     struct
-      type cluster = { index: int; merged_at: float; set: S.t; children: (cluster * cluster) option; }
+      type cluster = { uid: int; merged_at: float; set: S.t; children: (cluster * cluster) option; }
 
-      let precompute_dist len =
-        let len_total = len * 2 - 1 in
-        let table = Array.init len_total (fun i ->
-            Array.init len_total (fun j ->
-                if i = j
-                then Some 0.0
-                else None
-              ))
-        in
-        fun clusters c1 c2 ->
-          let i,j = min c1.index c2.index, max c1.index c2.index in
-          match table.(i).(j) with
-          | Some dist -> dist
-          | None ->
-            let dist = S.dist (List.nth clusters i).set (List.nth clusters j).set in
-            table.(i).(j) <- Some dist;
-            table.(j).(i) <- Some dist;
-            dist
+      let uid =
+        let x = ref (-1) in
+        fun () ->
+          incr x ;
+          !x
+
+      let mkcluster set = { set; merged_at = 0.; children = None; uid = uid () }
+
+      (* Hash distance computation between clusters. *)
+      module Table = Hashtbl.Make (struct
+          type t = cluster * cluster
+
+          let equal (c1, c2) (c1', c2') =
+            (c1.uid = c1'.uid && c2.uid = c2'.uid)
+            || (c1.uid = c2'.uid && c2.uid = c1'.uid)
+
+          let hash (c1, c2) =
+            if c1.uid < c2.uid then Hashtbl.hash (c1.uid, c2.uid)
+            else Hashtbl.hash (c2.uid, c1.uid)
+        end)
+
+      let dist sz =
+        let table = Table.create sz in
+        fun c1 c2 ->
+          let c1, c2 = if c1.uid < c2.uid then c1, c2 else c2, c1 in
+          if c1.uid = c2.uid then 0.0
+          else
+            match Table.find_opt table (c1, c2) with
+            | Some dist -> dist
+            | None ->
+              let dist = S.dist c1.set c2.set in
+              Table.add table (c1, c2) dist ;
+              dist
 
       let minimum_pairwise_distance (dist : cluster -> cluster -> float) clusters =
         match clusters with
@@ -44,32 +59,33 @@ module Make =
           let seq = List.to_seq clusters |> (fun x -> Seq.product x x) in
           Seq.fold_left (fun ((dist_min, _, _) as acc) (a,b) ->
               let dist_new = dist a b in
-              if a.index = b.index || dist_new > dist_min
+              if a.uid = b.uid || dist_new > dist_min
               then acc
               else (dist_new, a, b)
             ) (dist c1 c2, c1, c2) seq
 
       let cluster_with_initial element_sets =
-        let dist = precompute_dist (List.length element_sets) in
+        (* The number of sets in total is |elements| * 2 - 1 because each new cluster combines two elements. *)
+        (* We end with exactly one cluster remaining. *)
+        let dist = dist (List.length element_sets * 2 - 1) in
         let len = List.length element_sets in
-        let clusters =
-          List.mapi (fun index set -> {index; merged_at = 0.; set; children = None; }) element_sets;
-        in
+        let clusters = List.map mkcluster element_sets in
 
-        let rec iterate index clusters active_clusters =
+        let rec iterate index active_clusters =
           match active_clusters with
           | [] -> failwith "No cluster left."
           | [c] -> c
           | _ ->
-            let merged_at, left, right = minimum_pairwise_distance (dist clusters) active_clusters in
+            let merged_at, left, right = minimum_pairwise_distance dist active_clusters in
             let set = S.join left.set right.set in
-            let cluster_new = {index; merged_at; set; children = Some (left, right); } in
-            let clusters = clusters @ [cluster_new] in
-            let active_clusters = cluster_new :: List.filter (fun x -> x.index != left.index && x.index != right.index) active_clusters in
-            Printf.printf "Joined %i %i\n" left.index right.index;
-            iterate (index+1) clusters active_clusters
+            let cluster_new = {uid = uid (); merged_at; set; children = Some (left, right); } in
+            let active_clusters =
+              cluster_new
+              :: List.filter (fun x -> x.uid != left.uid && x.uid != right.uid) active_clusters
+            in
+            iterate (index+1) active_clusters
         in
-        iterate len clusters clusters
+        iterate len clusters
 
       let cluster elements =
         List.map (fun x -> S.singleton x) elements

--- a/agglomerative.ml
+++ b/agglomerative.ml
@@ -11,82 +11,82 @@ module type Element_set = sig
 end
 
 module Make =
-functor
-  (E : Intf.Metric)
-  (S : Element_set with type elt = E.t)
-  ->
-  struct
-    type cluster = { set : S.t; tree : tree; uid : int }
+  functor
+    (E : Intf.Metric)
+    (S : Element_set with type elt = E.t)
+    ->
+    struct
+      type cluster = { set : S.t; tree : tree; uid : int }
 
-    and tree = Node of cluster * cluster | Leaf
+      and tree = Node of cluster * cluster | Leaf
 
-    let uid =
-      let x = ref (-1) in
-      fun () ->
-        incr x ;
-        !x
+      let uid =
+        let x = ref (-1) in
+        fun () ->
+          incr x ;
+          !x
 
-    let mkcluster set tree = { set; tree; uid = uid () }
+      let mkcluster set tree = { set; tree; uid = uid () }
 
-    (* Hash distance computation between clusters. *)
-    module Table = Hashtbl.Make (struct
-      type t = cluster * cluster
+      (* Hash distance computation between clusters. *)
+      module Table = Hashtbl.Make (struct
+          type t = cluster * cluster
 
-      let equal (c1, c2) (c1', c2') =
-        (c1.uid = c1'.uid && c2.uid = c2'.uid)
-        || (c1.uid = c2'.uid && c2.uid = c1'.uid)
+          let equal (c1, c2) (c1', c2') =
+            (c1.uid = c1'.uid && c2.uid = c2'.uid)
+            || (c1.uid = c2'.uid && c2.uid = c1'.uid)
 
-      let hash (c1, c2) =
-        if c1.uid < c2.uid then Hashtbl.hash (c1.uid, c2.uid)
-        else Hashtbl.hash (c2.uid, c1.uid)
-    end)
+          let hash (c1, c2) =
+            if c1.uid < c2.uid then Hashtbl.hash (c1.uid, c2.uid)
+            else Hashtbl.hash (c2.uid, c1.uid)
+        end)
 
-    let dist sz =
-      let table = Table.create sz in
-      fun c1 c2 ->
-        if c1.uid = c2.uid then 0.0
-        else
-          match Table.find_opt table (c1, c2) with
-          | Some dist -> dist
-          | None ->
+      let dist sz =
+        let table = Table.create sz in
+        fun c1 c2 ->
+          if c1.uid = c2.uid then 0.0
+          else
+            match Table.find_opt table (c1, c2) with
+            | Some dist -> dist
+            | None ->
               let dist = S.dist c1.set c2.set in
               Table.add table (c1, c2) dist ;
               dist
 
-    let minimum_pairwise_distance (dist : cluster -> cluster -> float) clusters
+      let minimum_pairwise_distance (dist : cluster -> cluster -> float) clusters
         =
-      match clusters with
-      | [] -> invalid_arg "empty cluster list"
-      | [c] -> (0.0, c, c)
-      | c :: c' :: _tl ->
+        match clusters with
+        | [] -> invalid_arg "empty cluster list"
+        | [c] -> (0.0, c, c)
+        | c :: c' :: _tl ->
           let (acc, _) =
             List.fold_left
               (fun (acc, i) c ->
-                let (acc, _) =
-                  List.fold_left
-                    (fun (acc, j) c' ->
-                      let acc =
-                        if j > i then
-                          let (best_d, _, _) = acc in
-                          let d = dist c c' in
-                          if d < best_d then (d, c, c') else acc
-                        else acc
-                      in
-                      (acc, j + 1))
-                    (acc, 0)
-                    clusters
-                in
-                (acc, i + 1))
+                 let (acc, _) =
+                   List.fold_left
+                     (fun (acc, j) c' ->
+                        let acc =
+                          if j > i then
+                            let (best_d, _, _) = acc in
+                            let d = dist c c' in
+                            if d < best_d then (d, c, c') else acc
+                          else acc
+                        in
+                        (acc, j + 1))
+                     (acc, 0)
+                     clusters
+                 in
+                 (acc, i + 1))
               ((dist c c', c, c'), 0)
               clusters
           in
           acc
 
-    let rec iterate dist clusters =
-      match clusters with
-      | [] -> invalid_arg "empty cluster list"
-      | [c] -> c
-      | _ ->
+      let rec iterate dist clusters =
+        match clusters with
+        | [] -> invalid_arg "empty cluster list"
+        | [c] -> c
+        | _ ->
           let (_d, c, c') = minimum_pairwise_distance dist clusters in
           let clusters =
             List.filter (fun c0 -> c0.uid <> c.uid && c0.uid <> c'.uid) clusters
@@ -94,40 +94,40 @@ functor
           let joined = mkcluster (S.join c.set c'.set) (Node (c, c')) in
           iterate dist (joined :: clusters)
 
-    let cluster elements =
-      let len = List.length elements in
-      let dist = dist len in
-      let clusters =
-        List.map (fun x -> mkcluster (S.singleton x) Leaf) elements
-      in
-      iterate dist clusters
+      let cluster elements =
+        let len = List.length elements in
+        let dist = dist len in
+        let clusters =
+          List.map (fun x -> mkcluster (S.singleton x) Leaf) elements
+        in
+        iterate dist clusters
 
-    let truncate cluster depth =
-      let rec truncate { set; tree; _ } depth queue acc =
-        match tree with
-        | Leaf -> (
-            if depth > 0 then invalid_arg "truncate: tree too short"
-            else
-              let acc = set :: acc in
-              match queue with
-              | [] -> acc
-              | (next, d) :: tl -> truncate next d tl acc)
-        | Node (l, r) ->
+      let truncate cluster depth =
+        let rec truncate { set; tree; _ } depth queue acc =
+          match tree with
+          | Leaf -> (
+              if depth > 0 then invalid_arg "truncate: tree too short"
+              else
+                let acc = set :: acc in
+                match queue with
+                | [] -> acc
+                | (next, d) :: tl -> truncate next d tl acc)
+          | Node (l, r) ->
             if depth = 0 then
               let acc = set :: acc in
               match queue with
               | [] -> acc
               | (next, d) :: tl -> truncate next d tl acc
             else truncate l (depth - 1) ((r, depth - 1) :: queue) acc
-      in
-      truncate cluster depth [] []
+        in
+        truncate cluster depth [] []
 
-    let all_clusters cluster =
-      let rec fold { set; tree; _ } depth acc =
-        match tree with
-        | Leaf -> (set, depth) :: acc
-        | Node (l, r) ->
+      let all_clusters cluster =
+        let rec fold { set; tree; _ } depth acc =
+          match tree with
+          | Leaf -> (set, depth) :: acc
+          | Node (l, r) ->
             fold r (depth + 1) (fold l (depth + 1) ((set, depth) :: acc))
-      in
-      fold cluster 0 []
-  end
+        in
+        fold cluster 0 []
+    end

--- a/agglomerative.mli
+++ b/agglomerative.mli
@@ -30,7 +30,7 @@ module Make : functor
   (E : Intf.Metric)
   (S : Element_set with type elt = E.t)
   -> sig
-  type cluster = { index: int; merged_at: float; set: S.t; children: (cluster * cluster) option; }
+  type cluster = { uid: int; merged_at: float; set: S.t; tree: (cluster * cluster) option; }
 
   val cluster_with_initial : S.t list -> cluster
 

--- a/agglomerative.mli
+++ b/agglomerative.mli
@@ -30,7 +30,7 @@ module Make : functor
   (E : Intf.Metric)
   (S : Element_set with type elt = E.t)
   -> sig
-  type cluster = { index: int; set: S.t; children: (cluster * cluster) option; }
+  type cluster = { index: int; merged_at: float; set: S.t; children: (cluster * cluster) option; }
 
   val cluster_with_initial : S.t list -> cluster
 

--- a/agglomerative.mli
+++ b/agglomerative.mli
@@ -30,9 +30,7 @@ module Make : functor
   (E : Intf.Metric)
   (S : Element_set with type elt = E.t)
   -> sig
-  type cluster = { set : S.t; tree : tree; index : int }
-
-  and tree = Node of cluster * cluster | Leaf
+  type cluster = { index: int; set: S.t; children: (cluster * cluster) option; }
 
   val cluster_with_initial : S.t list -> cluster
 

--- a/agglomerative.mli
+++ b/agglomerative.mli
@@ -34,6 +34,8 @@ module Make : functor
 
   and tree = Node of cluster * cluster | Leaf
 
+  val cluster_with_initial : S.t list -> cluster
+
   val cluster : E.t list -> cluster
 
   (** [truncate c depth] returns all the sub-clusters at depth [depth].

--- a/agglomerative.mli
+++ b/agglomerative.mli
@@ -30,7 +30,7 @@ module Make : functor
   (E : Intf.Metric)
   (S : Element_set with type elt = E.t)
   -> sig
-  type cluster = { set : S.t; tree : tree; uid : int }
+  type cluster = { set : S.t; tree : tree; index : int }
 
   and tree = Node of cluster * cluster | Leaf
 

--- a/dune
+++ b/dune
@@ -1,2 +1,4 @@
-(library (public_name prbnmcn-clustering) (name clustering)
-  (ocamlopt_flags -O3 (-warn-error -39)))
+(library
+ (public_name prbnmcn-clustering)
+ (name clustering)
+ (ocamlopt_flags -O3 (-warn-error -39)))


### PR DESCRIPTION
This PR refactors the agglomerative clustering algorithm and adds a merged_at field to clusters which represents the distance between the two clusters. As it was easy to implement it also adds a `cluster_with_initial` function that allows you to start the clustering with some predefined clusters.

This PR is not as polished/minimal as it could be. For example, the change to the cluster type could be more minimal, whitespace changes etc. As such, it is a breaking change with only small benefits. Maybe this can be refactored a bit further before merging or this simply stays here for those that need those two features. Unfortunately, I am done with my project and am not interested in spending a lot more time on this PR.
